### PR TITLE
feat: add dark mode support with Tailwind CSS

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,10 +2,11 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import tailwind from '@astrojs/tailwind';
 
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://garyp.github.io',
         base: '/gloriousoblivion.org',
-	integrations: [mdx(), sitemap()],
+	integrations: [mdx(), sitemap(), tailwind()],
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@astrojs/tailwind": "^5.2.1",
     "astro": "^5.9.3",
     "sharp": "^0.34.2",
-    "tailwindcss": "^3.4.19"
+    "tailwindcss": "^4.0.0"
   },
   "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "@astrojs/mdx": "^4.3.0",
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.4.1",
+    "@astrojs/tailwind": "^5.2.1",
     "astro": "^5.9.3",
-    "sharp": "^0.34.2"
+    "sharp": "^0.34.2",
+    "tailwindcss": "^3.4.19"
   },
   "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -4,6 +4,7 @@
 import '../styles/global.css';
 import { SITE_TITLE } from '../consts';
 import FallbackImage from '../assets/blog-placeholder-1.jpg';
+import ThemeScript from './ThemeScript.astro';
 import type { ImageMetadata } from 'astro';
 
 interface Props {
@@ -29,6 +30,9 @@ const { title, description, image = FallbackImage } = Astro.props;
 	href={new URL('rss.xml', Astro.site)}
 />
 <meta name="generator" content={Astro.generator} />
+
+<!-- Theme script to prevent FOUC -->
+<ThemeScript />
 
 <!-- Font preloads -->
 <link rel="preload" href="/fonts/atkinson-regular.woff" as="font" type="font/woff" crossorigin />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import HeaderLink from './HeaderLink.astro';
+import ThemeToggle from './ThemeToggle.astro';
 import { SITE_TITLE } from '../consts';
 ---
 
@@ -10,6 +11,9 @@ import { SITE_TITLE } from '../consts';
 			<HeaderLink href="/">Home</HeaderLink>
 			<HeaderLink href="/blog">Blog</HeaderLink>
 			<HeaderLink href="/about">About</HeaderLink>
+		</div>
+		<div class="nav-actions">
+			<ThemeToggle />
 		</div>
 		<div class="social-links">
 			<a href="https://m.webtoo.ls/@astro" target="_blank">
@@ -48,6 +52,12 @@ import { SITE_TITLE } from '../consts';
 		padding: 0 1em;
 		background: white;
 		box-shadow: 0 2px 8px rgba(var(--black), 5%);
+		transition: background-color 0.2s ease;
+	}
+	
+	:global(.dark) header {
+		background: rgb(var(--gray-dark));
+		color: rgb(var(--gray-light));
 	}
 	h2 {
 		margin: 0;
@@ -62,6 +72,13 @@ import { SITE_TITLE } from '../consts';
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		gap: 1rem;
+	}
+	
+	.nav-actions {
+		display: flex;
+		align-items: center;
+		margin: 0 0.5rem;
 	}
 	nav a {
 		padding: 1em 0.5em;
@@ -72,6 +89,10 @@ import { SITE_TITLE } from '../consts';
 	nav a.active {
 		text-decoration: none;
 		border-bottom-color: var(--accent);
+	}
+	
+	:global(.dark) nav a {
+		color: rgb(var(--gray-light));
 	}
 	.social-links,
 	.social-links a {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,19 +4,21 @@ import ThemeToggle from './ThemeToggle.astro';
 import { SITE_TITLE } from '../consts';
 ---
 
-<header>
-	<nav>
-		<h2><a href="/">{SITE_TITLE}</a></h2>
+<header class="m-0 px-4 bg-white shadow-md transition-colors duration-200 dark:bg-gray-800 dark:text-gray-200">
+	<nav class="flex items-center justify-between gap-4">
+		<h2 class="m-0 text-base">
+			<a href="/" class="no-underline text-gray-900 dark:text-gray-100">{SITE_TITLE}</a>
+		</h2>
 		<div class="internal-links">
 			<HeaderLink href="/">Home</HeaderLink>
 			<HeaderLink href="/blog">Blog</HeaderLink>
 			<HeaderLink href="/about">About</HeaderLink>
 		</div>
-		<div class="nav-actions">
+		<div class="flex items-center mx-2">
 			<ThemeToggle />
 		</div>
-		<div class="social-links">
-			<a href="https://m.webtoo.ls/@astro" target="_blank">
+		<div class="social-links flex md:flex hidden">
+			<a href="https://m.webtoo.ls/@astro" target="_blank" class="flex text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors duration-200">
 				<span class="sr-only">Follow Astro on Mastodon</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
 					><path
@@ -25,7 +27,7 @@ import { SITE_TITLE } from '../consts';
 					></path></svg
 				>
 			</a>
-			<a href="https://twitter.com/astrodotbuild" target="_blank">
+			<a href="https://twitter.com/astrodotbuild" target="_blank" class="flex text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors duration-200">
 				<span class="sr-only">Follow Astro on Twitter</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
 					><path
@@ -34,7 +36,7 @@ import { SITE_TITLE } from '../consts';
 					></path></svg
 				>
 			</a>
-			<a href="https://github.com/withastro/astro" target="_blank">
+			<a href="https://github.com/withastro/astro" target="_blank" class="flex text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors duration-200">
 				<span class="sr-only">Go to Astro's GitHub repo</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
 					><path
@@ -46,61 +48,3 @@ import { SITE_TITLE } from '../consts';
 		</div>
 	</nav>
 </header>
-<style>
-	header {
-		margin: 0;
-		padding: 0 1em;
-		background: white;
-		box-shadow: 0 2px 8px rgba(var(--black), 5%);
-		transition: background-color 0.2s ease;
-	}
-	
-	:global(.dark) header {
-		background: rgb(var(--gray-dark));
-		color: rgb(var(--gray-light));
-	}
-	h2 {
-		margin: 0;
-		font-size: 1em;
-	}
-
-	h2 a,
-	h2 a.active {
-		text-decoration: none;
-	}
-	nav {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1rem;
-	}
-	
-	.nav-actions {
-		display: flex;
-		align-items: center;
-		margin: 0 0.5rem;
-	}
-	nav a {
-		padding: 1em 0.5em;
-		color: var(--black);
-		border-bottom: 4px solid transparent;
-		text-decoration: none;
-	}
-	nav a.active {
-		text-decoration: none;
-		border-bottom-color: var(--accent);
-	}
-	
-	:global(.dark) nav a {
-		color: rgb(var(--gray-light));
-	}
-	.social-links,
-	.social-links a {
-		display: flex;
-	}
-	@media (max-width: 720px) {
-		.social-links {
-			display: none;
-		}
-	}
-</style>

--- a/src/components/ThemeScript.astro
+++ b/src/components/ThemeScript.astro
@@ -1,0 +1,21 @@
+---
+// Theme initialization script to prevent FOUC (Flash of Unstyled Content)
+---
+
+<script is:inline>
+  // This script runs immediately to prevent FOUC
+  (function() {
+    function setTheme() {
+      const savedTheme = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      
+      if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    }
+    
+    setTheme();
+  })();
+</script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,136 @@
+---
+// ThemeToggle component for switching between light and dark modes
+---
+
+<button
+  id="theme-toggle"
+  class="theme-toggle-btn"
+  aria-label="Toggle dark mode"
+  title="Toggle dark mode"
+>
+  <svg class="sun-icon" viewBox="0 0 24 24" width="20" height="20">
+    <circle cx="12" cy="12" r="5"/>
+    <line x1="12" y1="1" x2="12" y2="3"/>
+    <line x1="12" y1="21" x2="12" y2="23"/>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+    <line x1="1" y1="12" x2="3" y2="12"/>
+    <line x1="21" y1="12" x2="23" y2="12"/>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <svg class="moon-icon" viewBox="0 0 24 24" width="20" height="20">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
+<style>
+  .theme-toggle-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    border-radius: 0.375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease;
+    color: rgb(var(--black));
+  }
+
+  .theme-toggle-btn:hover {
+    background-color: rgba(var(--gray-light), 0.5);
+  }
+
+  .sun-icon,
+  .moon-icon {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .moon-icon {
+    fill: currentColor;
+    stroke: none;
+  }
+
+  /* Show sun icon in dark mode, moon icon in light mode */
+  .sun-icon {
+    opacity: 0;
+    transform: rotate(90deg);
+  }
+
+  .moon-icon {
+    opacity: 1;
+    transform: rotate(0deg);
+    position: absolute;
+  }
+
+  :global(.dark) .sun-icon {
+    opacity: 1;
+    transform: rotate(0deg);
+  }
+
+  :global(.dark) .moon-icon {
+    opacity: 0;
+    transform: rotate(-90deg);
+  }
+
+  :global(.dark) .theme-toggle-btn {
+    color: rgb(var(--gray-light));
+  }
+
+  :global(.dark) .theme-toggle-btn:hover {
+    background-color: rgba(var(--gray-dark), 0.5);
+  }
+</style>
+
+<script>
+  function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    
+    function setTheme(theme) {
+      if (theme === 'dark') {
+        document.documentElement.classList.add('dark');
+        localStorage.setItem('theme', 'dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+        localStorage.setItem('theme', 'light');
+      }
+    }
+
+    function toggleTheme() {
+      const isDark = document.documentElement.classList.contains('dark');
+      setTheme(isDark ? 'light' : 'dark');
+    }
+
+    // Initialize theme on page load
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    
+    if (savedTheme) {
+      setTheme(savedTheme);
+    } else if (prefersDark) {
+      setTheme('dark');
+    }
+
+    // Add click event listener
+    themeToggle?.addEventListener('click', toggleTheme);
+
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        setTheme(e.matches ? 'dark' : 'light');
+      }
+    });
+  }
+
+  // Initialize on page load
+  initThemeToggle();
+
+  // Re-initialize on navigation (for SPA-like behavior)
+  document.addEventListener('astro:page-load', initThemeToggle);
+</script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -4,11 +4,11 @@
 
 <button
   id="theme-toggle"
-  class="theme-toggle-btn"
+  class="bg-transparent border-none cursor-pointer p-2 rounded-md flex items-center justify-center transition-colors duration-200 text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
   aria-label="Toggle dark mode"
   title="Toggle dark mode"
 >
-  <svg class="sun-icon" viewBox="0 0 24 24" width="20" height="20">
+  <svg class="sun-icon w-5 h-5 opacity-0 rotate-90 transition-all duration-200 dark:opacity-100 dark:rotate-0 absolute" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="5"/>
     <line x1="12" y1="1" x2="12" y2="3"/>
     <line x1="12" y1="21" x2="12" y2="23"/>
@@ -19,74 +19,10 @@
     <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
     <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
   </svg>
-  <svg class="moon-icon" viewBox="0 0 24 24" width="20" height="20">
+  <svg class="moon-icon w-5 h-5 opacity-100 rotate-0 transition-all duration-200 dark:opacity-0 dark:-rotate-90" viewBox="0 0 24 24" fill="currentColor">
     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
   </svg>
 </button>
-
-<style>
-  .theme-toggle-btn {
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    padding: 0.5rem;
-    border-radius: 0.375rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color 0.2s ease;
-    color: rgb(var(--black));
-  }
-
-  .theme-toggle-btn:hover {
-    background-color: rgba(var(--gray-light), 0.5);
-  }
-
-  .sun-icon,
-  .moon-icon {
-    fill: none;
-    stroke: currentColor;
-    stroke-width: 2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    transition: opacity 0.2s ease, transform 0.2s ease;
-  }
-
-  .moon-icon {
-    fill: currentColor;
-    stroke: none;
-  }
-
-  /* Show sun icon in dark mode, moon icon in light mode */
-  .sun-icon {
-    opacity: 0;
-    transform: rotate(90deg);
-  }
-
-  .moon-icon {
-    opacity: 1;
-    transform: rotate(0deg);
-    position: absolute;
-  }
-
-  :global(.dark) .sun-icon {
-    opacity: 1;
-    transform: rotate(0deg);
-  }
-
-  :global(.dark) .moon-icon {
-    opacity: 0;
-    transform: rotate(-90deg);
-  }
-
-  :global(.dark) .theme-toggle-btn {
-    color: rgb(var(--gray-light));
-  }
-
-  :global(.dark) .theme-toggle-btn:hover {
-    background-color: rgba(var(--gray-dark), 0.5);
-  }
-</style>
 
 <script>
   function initThemeToggle() {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,6 +16,17 @@
 		0 2px 6px rgba(var(--gray), 25%), 0 8px 24px rgba(var(--gray), 33%),
 		0 16px 32px rgba(var(--gray), 33%);
 }
+
+/* Dark mode color overrides */
+.dark {
+	--black: 255, 255, 255;
+	--gray: 229, 233, 240;
+	--gray-light: 96, 115, 159;
+	--gray-dark: 229, 233, 240;
+	--gray-gradient: rgba(34, 41, 57, 50%), rgb(15, 18, 25);
+	--accent: #4f46e5;
+	--accent-dark: #6366f1;
+}
 @font-face {
 	font-family: 'Atkinson';
 	src: url('/fonts/atkinson-regular.woff') format('woff');
@@ -42,6 +53,13 @@ body {
 	color: rgb(var(--gray-dark));
 	font-size: 20px;
 	line-height: 1.7;
+	transition: color 0.2s ease, background 0.2s ease;
+}
+
+.dark body {
+	background: linear-gradient(var(--gray-gradient)) no-repeat;
+	background-size: 100% 600px;
+	color: rgb(var(--gray-light));
 }
 main {
 	width: 720px;
@@ -58,6 +76,7 @@ h6 {
 	margin: 0 0 0.5rem 0;
 	color: rgb(var(--black));
 	line-height: 1.2;
+	transition: color 0.2s ease;
 }
 h1 {
 	font-size: 3.052em;
@@ -109,10 +128,21 @@ code {
 	padding: 2px 5px;
 	background-color: rgb(var(--gray-light));
 	border-radius: 2px;
+	transition: background-color 0.2s ease;
 }
+
+.dark code {
+	background-color: rgba(var(--gray-dark), 0.3);
+}
+
 pre {
 	padding: 1.5em;
 	border-radius: 8px;
+	transition: background-color 0.2s ease;
+}
+
+.dark pre {
+	background-color: rgba(var(--gray-dark), 0.3);
 }
 pre > code {
 	all: unset;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,6 @@
+/* Import Tailwind CSS (Tailwind 4 syntax) */
+@import "tailwindcss";
+
 /*
   The CSS in this style tag is based off of Bear Blog's default CSS.
   https://github.com/HermanMartinus/bearblog/blob/297026a877bc2ab2b3bdfbd6b9f7961c350917dd/templates/styles/blog/default.css

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        accent: '#2337ff',
+        'accent-dark': '#000d8a',
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
This PR adds dark mode support to the Astro blog following the requirements in issue #2.

## Changes
- Install Astro Tailwind CSS integration
- Create ThemeToggle component with sun/moon icons
- Add dark mode CSS custom properties
- Implement theme persistence with localStorage
- Prevent flash of unstyled content (FOUC)

Resolves #2

🤖 Generated with [Claude Code](https://claude.ai/code)